### PR TITLE
Content-length Calculation Fix

### DIFF
--- a/api.js
+++ b/api.js
@@ -101,7 +101,7 @@ module.exports = ( conn ) => {
                 headers,
                 {
                     'Content-Type': 'application/json',
-                    'Content-Length': body.length
+                    'Content-Length': Buffer.byteLength(body, "utf8")
                 },
                 params['If-None-Match'] ? { 'If-None-Match': params['If-None-Match'] } : undefined
             ),
@@ -128,7 +128,7 @@ module.exports = ( conn ) => {
             method: 'POST',
             headers: Object.assign(headers, {
                 'Content-Type': 'application/json',
-                'Content-Length': body.length
+                'Content-Length': Buffer.byteLength(body, "utf8")
             }),
             host, port,
             path: url
@@ -153,7 +153,7 @@ module.exports = ( conn ) => {
             method: 'DELETE',
             headers: Object.assign(headers, {
                 'Content-Type': 'application/json',
-                'Content-Length': body.length
+                'Content-Length': Buffer.byteLength(body, "utf8")
             }),
             host, port,
             path: url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cos-api4node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Atelier REST API wrapper",
   "repository": {
     "type": "git",


### PR DESCRIPTION
На некоторых документах (например, с кириллицей) неправильно считалось Content-Length, из-за чего Caché не принимал запросы. Этот PR исправляет это.

Отправлю PR ещё и в vs-code после этого. Спасибо!